### PR TITLE
Style: Fix overlapping Doc Versions buttons.

### DIFF
--- a/resources/views/components/project.blade.php
+++ b/resources/views/components/project.blade.php
@@ -3,7 +3,7 @@
         <h3 class="text-xl font-bold">{{ package_to_title($project['name']) }}</h3>
     </a>
 
-    <p class="flex-1 mt-2 text-gray-700">
+    <p class="mt-2 text-gray-700">
         {{ $project['description'] }}
     </p>
 
@@ -48,7 +48,7 @@
         </a>
     </div>
 
-    <ul class="flex items-center space-x-2 mt-4">
+    <ul class="flex flex-wrap items-center space-x-2 mt-4">
         @foreach($project['versions'] as $version)
             @if($loop->first)
                 <li class="text-xs">Doc Versions:</li>


### PR DESCRIPTION

This pull request makes minor UI improvements to the `project.blade.php` component. The changes focus on better layout handling for project descriptions and version tags.

- Layout and styling improvements:
  * Removed the `flex-1` class from the project description paragraph to prevent unwanted stretching and ensure consistent alignment.
  * Added `flex-wrap` to the versions list to allow version tags to wrap onto multiple lines if needed, improving responsiveness and display on smaller screens.

<!--

Thanks for the Pull Request!  Before you submit the PR, please
look over this checklist:

- Have you read the [Contributing Guidelines]( https://github.com/yajra/yajrabox.com/blob/main/.github/CONTRIBUTING.md)?

If you answered yes, thanks for the PR and we'll get to it ASAP! :)

-->
